### PR TITLE
Rename leader event types to match other events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -9,8 +9,8 @@ class UpdateStatusEvent(EventBase): pass
 class UpgradeCharmEvent(EventBase): pass
 class PreSeriesUpgradeEvent(EventBase): pass
 class PostSeriesUpgradeEvent(EventBase): pass
-class LeaderElected(EventBase): pass
-class LeaderSettingsChanged(EventBase): pass
+class LeaderElectedEvent(EventBase): pass
+class LeaderSettingsChangedEvent(EventBase): pass
 
 
 class CharmEvents(EventsBase):
@@ -23,8 +23,8 @@ class CharmEvents(EventsBase):
     upgrade_charm = Event(UpgradeCharmEvent)
     pre_series_upgrade = Event(PreSeriesUpgradeEvent)
     post_series_upgrade = Event(PostSeriesUpgradeEvent)
-    leader_elected = Event(LeaderElected)
-    leader_settings_changed = Event(LeaderSettingsChanged)
+    leader_elected = Event(LeaderElectedEvent)
+    leader_settings_changed = Event(LeaderSettingsChangedEvent)
 
 
 class Charm(Object):


### PR DESCRIPTION
"Event" suffix is used by convention.