### PR TITLE
Rename Charm and CharmEvents to have Base suffix

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -27,6 +27,6 @@ class CharmEvents(EventsBase):
     leader_settings_changed = Event(LeaderSettingsChangedEvent)
 
 
-class Charm(Object):
+class CharmBase(Object):
 
     on = CharmEvents()


### PR DESCRIPTION
According to the prior discussion, developers will extend CharmBase and
CharmEventsBase to define their own Charm and CharmEvents.