### PR TITLE
Add model classes for metadata and helpers for relation / storage events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -110,15 +110,14 @@ class CharmMeta:
         self.name = raw.get('name', '')
         self.summary = raw.get('summary', '')
         self.description = raw.get('description', '')
-        maintainers = []
+        self.maintainers = []
         if 'maintainer' in raw:
-            maintainers.append(raw['maintainer'])
+            self.maintainers.append(raw['maintainer'])
         if 'maintainers' in raw:
-            maintainers.extend(raw['maintainers'])
-        self.maintainers = tuple(maintainers)
-        self.tags = tuple(raw.get('tags', []))
-        self.terms = tuple(raw.get('terms', []))
-        self.series = tuple(raw.get('series', []))
+            self.maintainers.extend(raw['maintainers'])
+        self.tags = raw.get('tags', [])
+        self.terms = raw.get('terms', [])
+        self.series = raw.get('series', [])
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
         self.requires = {name: RelationMeta('requires', name, rel)
@@ -137,7 +136,7 @@ class CharmMeta:
                           for name, res in raw.get('resources', {}).items()}
         self.payloads = {name: PayloadMeta(name, payload)
                          for name, payload in raw.get('payloads', {}).items()}
-        self.extra_bindings = tuple(raw.get('extra-bindings', {}))
+        self.extra_bindings = raw.get('extra-bindings', [])
 
 
 class RelationMeta:

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from juju.framework import Object, Event, EventBase, EventsBase
 
 
@@ -72,6 +73,40 @@ class CharmEvents(EventsBase):
     post_series_upgrade = Event(PostSeriesUpgradeEvent)
     leader_elected = Event(LeaderElectedEvent)
     leader_settings_changed = Event(LeaderSettingsChangedEvent)
+
+    @property
+    def relation(self):
+        """Convenience accessor for accessing relation events by relation name.
+
+        Example usage::
+
+            framework.observe(charm.on.relation["db"].joined, charm)
+            charm.on.relation["db"].broken.emit()
+        """
+        groups = {}
+        for event_kind, bound_event in self.events().items():
+            if '_relation_' in event_kind:
+                relation_name, _, event_name = event_kind.split('_')
+                ns = groups.setdefault(relation_name, SimpleNamespace())
+                setattr(ns, event_name, bound_event)
+        return groups
+
+    @property
+    def storage(self):
+        """Convenience accessor for accessing storage events by storage name.
+
+        Example usage::
+
+            framework.observe(charm.on.storage["cache"].attached, charm)
+            charm.on.storage["cache"].detaching.emit()
+        """
+        groups = {}
+        for event_kind, bound_event in self.events().items():
+            if '_storage_' in event_kind:
+                storage_name, _, event_name = event_kind.split('_')
+                ns = groups.setdefault(storage_name, SimpleNamespace())
+                setattr(ns, event_name, bound_event)
+        return groups
 
 
 class CharmBase(Object):

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from juju.framework import Object, Event, EventBase, EventsBase
 
 
@@ -73,40 +72,6 @@ class CharmEvents(EventsBase):
     post_series_upgrade = Event(PostSeriesUpgradeEvent)
     leader_elected = Event(LeaderElectedEvent)
     leader_settings_changed = Event(LeaderSettingsChangedEvent)
-
-    @property
-    def relation(self):
-        """Convenience accessor for accessing relation events by relation name.
-
-        Example usage::
-
-            framework.observe(charm.on.relation["db"].joined, charm)
-            charm.on.relation["db"].broken.emit()
-        """
-        groups = {}
-        for event_kind, bound_event in self.events().items():
-            if '_relation_' in event_kind:
-                relation_name, _, event_name = event_kind.split('_')
-                ns = groups.setdefault(relation_name, SimpleNamespace())
-                setattr(ns, event_name, bound_event)
-        return groups
-
-    @property
-    def storage(self):
-        """Convenience accessor for accessing storage events by storage name.
-
-        Example usage::
-
-            framework.observe(charm.on.storage["cache"].attached, charm)
-            charm.on.storage["cache"].detaching.emit()
-        """
-        groups = {}
-        for event_kind, bound_event in self.events().items():
-            if '_storage_' in event_kind:
-                storage_name, _, event_name = event_kind.split('_')
-                ns = groups.setdefault(storage_name, SimpleNamespace())
-                setattr(ns, event_name, bound_event)
-        return groups
 
 
 class CharmBase(Object):

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -82,19 +82,145 @@ class CharmBase(Object):
         super().__init__(framework, key)
         self.metadata = metadata
 
-        for role in ('requires', 'provides', 'peers'):
-            for relation_name in metadata.get(role, ()):
-                self.on.define_event(f'{relation_name}_relation_joined',
-                                     RelationJoinedEvent)
-                self.on.define_event(f'{relation_name}_relation_changed',
-                                     RelationChangedEvent)
-                self.on.define_event(f'{relation_name}_relation_departed',
-                                     RelationDepartedEvent)
-                self.on.define_event(f'{relation_name}_relation_broken',
-                                     RelationBrokenEvent)
+        for relation_name in self.metadata.relations:
+            self.on.define_event(f'{relation_name}_relation_joined', RelationJoinedEvent)
+            self.on.define_event(f'{relation_name}_relation_changed', RelationChangedEvent)
+            self.on.define_event(f'{relation_name}_relation_departed', RelationDepartedEvent)
+            self.on.define_event(f'{relation_name}_relation_broken', RelationBrokenEvent)
 
-        for storage_name in metadata.get('storage', ()):
-            self.on.define_event(f'{storage_name}_storage_attached',
-                                 StorageAttachedEvent)
-            self.on.define_event(f'{storage_name}_storage_detaching',
-                                 StorageDetachingEvent)
+        for storage_name in metadata.storage:
+            self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
+            self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
+
+
+class CharmMetadata:
+    """Object containing the metadata for the charm.
+
+    Supported fields are:
+
+        * ``name``
+        * ``summary``
+        * ``description``
+        * ``maintainers``
+        * ``tags``
+        * ``terms``
+        * ``series``
+        * ``subordinate``
+        * ``min_juju_version``
+        * ``requires``
+        * ``provides``
+        * ``peers``
+        * ``relations``
+        * ``storage``
+        * ``resources``
+        * ``payloads``
+        * ``extra_bindings``
+
+    The ``maintainers``, ``tags``, ``terms``, ``series``, and ``extra_bindings``
+    attributes are all tuples of strings.  The ``requires``, ``provides``,
+    `peers``, ``relations``, ``storage``, ``resources``, and ``payloads``
+    attributes are all mappings of names to instances of the respective
+    :class:`RelationDefinition`, :class:`StorageDefinition`, :class:`ResourceDefinition`,
+    or :class:`PayloadDefinition`.
+
+    The ``relations`` attribute is a convenience accessor which includes all of
+    the ``requires``, ``provides``, and ``peers`` :class:`RelationDefinition`_
+    items.  If needed, the role of the relation definition can be obtained from
+    its ``role`` attribute.
+    """
+    def __init__(self, raw=None):
+        raw = raw or {}
+        self.name = raw.get('name', '')
+        self.summary = raw.get('summary', '')
+        self.description = raw.get('description', '')
+        maintainers = []
+        if 'maintainer' in raw:
+            maintainers.append(raw['maintainer'])
+        if 'maintainers' in raw:
+            maintainers.extend(raw['maintainers'])
+        self.maintainers = tuple(maintainers)
+        self.tags = tuple(raw.get('tags', []))
+        self.terms = tuple(raw.get('terms', []))
+        self.series = tuple(raw.get('series', []))
+        self.subordinate = raw.get('subordinate', False)
+        self.min_juju_version = raw.get('min-juju-version')
+        self.requires = {name: RelationDefinition('requires', name, rel)
+                         for name, rel in raw.get('requires', {}).items()}
+        self.provides = {name: RelationDefinition('provides', name, rel)
+                         for name, rel in raw.get('provides', {}).items()}
+        self.peers = {name: RelationDefinition('peers', name, rel)
+                      for name, rel in raw.get('peers', {}).items()}
+        self.relations = {}
+        self.relations.update(self.requires)
+        self.relations.update(self.provides)
+        self.relations.update(self.peers)
+        self.storage = {name: StorageDefinition(name, store)
+                        for name, store in raw.get('storage', {}).items()}
+        self.resources = {name: ResourceDefinition(name, res)
+                          for name, res in raw.get('resources', {}).items()}
+        self.payloads = {name: PayloadDefinition(name, payload)
+                         for name, payload in raw.get('payloads', {}).items()}
+        self.extra_bindings = tuple(raw.get('extra-bindings', {}))
+
+
+class RelationDefinition:
+    """Object containing metadata about a relation definition.
+
+    Supported fields are:
+
+        * ``role``
+        * ``relation_name``
+        * ``interface_name``
+        * ``scope``
+    """
+    def __init__(self, role, relation_name, raw):
+        self.role = role
+        self.relation_name = relation_name
+        self.interface_name = raw['interface']
+        self.scope = raw.get('scope')
+
+
+class StorageDefinition:
+    """Object containing metadata about a storage definition.
+
+    Supported fields are:
+    """
+    def __init__(self, name, raw):
+        self.storage_name = name
+        self.type = raw['type']
+        self.description = raw.get('description', '')
+        self.shared = raw.get('shared', False)
+        self.read_only = raw.get('read-only', False)
+        self.minimum_size = raw.get('minimum-size')
+        self.location = raw.get('location')
+        self.is_multiple = 'multiple' in raw
+        self.range = None
+        if self.is_multiple:
+            range = raw['multiple']['range']
+            if '-' not in range:
+                self.range = (int(range), int(range))
+            else:
+                range = range.split('-')
+                self.range = (int(range[0]), int(range[1]) if range[1] else None)
+
+
+class ResourceDefinition:
+    """Object containing metadata about a resource definition.
+
+    Supported fields are:
+    """
+    def __init__(self, name, raw):
+        self.resource_name = name
+        self.type = raw['type']
+        self.filename = raw['filename']
+        self.description = raw.get('description', '')
+
+
+class PayloadDefinition:
+    """Object containing metadata about a payload definition.
+
+    Supported fields are:
+    """
+    def __init__(self, name, raw):
+        self.payload_name = name
+        self.type = raw['type']

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -128,40 +128,17 @@ class CharmBase(Object):
             self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
 
 
-class CharmMetadata:
+class CharmMeta:
     """Object containing the metadata for the charm.
 
-    Supported fields are:
+    The maintainers, tags, terms, series, and extra_bindings attributes are all
+    lists of strings.  The requires, provides, peers, relations, storage,
+    resources, and payloads attributes are all mappings of names to instances
+    of the respective RelationMeta, StorageMeta, ResourceMeta, or PayloadMeta.
 
-        * ``name``
-        * ``summary``
-        * ``description``
-        * ``maintainers``
-        * ``tags``
-        * ``terms``
-        * ``series``
-        * ``subordinate``
-        * ``min_juju_version``
-        * ``requires``
-        * ``provides``
-        * ``peers``
-        * ``relations``
-        * ``storage``
-        * ``resources``
-        * ``payloads``
-        * ``extra_bindings``
-
-    The ``maintainers``, ``tags``, ``terms``, ``series``, and ``extra_bindings``
-    attributes are all tuples of strings.  The ``requires``, ``provides``,
-    `peers``, ``relations``, ``storage``, ``resources``, and ``payloads``
-    attributes are all mappings of names to instances of the respective
-    :class:`RelationDefinition`, :class:`StorageDefinition`, :class:`ResourceDefinition`,
-    or :class:`PayloadDefinition`.
-
-    The ``relations`` attribute is a convenience accessor which includes all of
-    the ``requires``, ``provides``, and ``peers`` :class:`RelationDefinition`_
-    items.  If needed, the role of the relation definition can be obtained from
-    its ``role`` attribute.
+    The relations attribute is a convenience accessor which includes all of the
+    requires, provides, and peers RelationMeta items.  If needed, the role of
+    the relation definition can be obtained from its role attribute.
     """
     def __init__(self, raw=None):
         raw = raw or {}
@@ -179,34 +156,28 @@ class CharmMetadata:
         self.series = tuple(raw.get('series', []))
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
-        self.requires = {name: RelationDefinition('requires', name, rel)
+        self.requires = {name: RelationMeta('requires', name, rel)
                          for name, rel in raw.get('requires', {}).items()}
-        self.provides = {name: RelationDefinition('provides', name, rel)
+        self.provides = {name: RelationMeta('provides', name, rel)
                          for name, rel in raw.get('provides', {}).items()}
-        self.peers = {name: RelationDefinition('peers', name, rel)
+        self.peers = {name: RelationMeta('peers', name, rel)
                       for name, rel in raw.get('peers', {}).items()}
         self.relations = {}
         self.relations.update(self.requires)
         self.relations.update(self.provides)
         self.relations.update(self.peers)
-        self.storage = {name: StorageDefinition(name, store)
+        self.storage = {name: StorageMeta(name, store)
                         for name, store in raw.get('storage', {}).items()}
-        self.resources = {name: ResourceDefinition(name, res)
+        self.resources = {name: ResourceMeta(name, res)
                           for name, res in raw.get('resources', {}).items()}
-        self.payloads = {name: PayloadDefinition(name, payload)
+        self.payloads = {name: PayloadMeta(name, payload)
                          for name, payload in raw.get('payloads', {}).items()}
         self.extra_bindings = tuple(raw.get('extra-bindings', {}))
 
 
-class RelationDefinition:
+class RelationMeta:
     """Object containing metadata about a relation definition.
 
-    Supported fields are:
-
-        * ``role``
-        * ``relation_name``
-        * ``interface_name``
-        * ``scope``
     """
     def __init__(self, role, relation_name, raw):
         self.role = role
@@ -215,10 +186,9 @@ class RelationDefinition:
         self.scope = raw.get('scope')
 
 
-class StorageDefinition:
+class StorageMeta:
     """Object containing metadata about a storage definition.
 
-    Supported fields are:
     """
     def __init__(self, name, raw):
         self.storage_name = name
@@ -228,21 +198,19 @@ class StorageDefinition:
         self.read_only = raw.get('read-only', False)
         self.minimum_size = raw.get('minimum-size')
         self.location = raw.get('location')
-        self.is_multiple = 'multiple' in raw
-        self.range = None
-        if self.is_multiple:
+        self.multiple_range = None
+        if 'multiple' in raw:
             range = raw['multiple']['range']
             if '-' not in range:
-                self.range = (int(range), int(range))
+                self.multiple_range = (int(range), int(range))
             else:
                 range = range.split('-')
-                self.range = (int(range[0]), int(range[1]) if range[1] else None)
+                self.multiple_range = (int(range[0]), int(range[1]) if range[1] else None)
 
 
-class ResourceDefinition:
+class ResourceMeta:
     """Object containing metadata about a resource definition.
 
-    Supported fields are:
     """
     def __init__(self, name, raw):
         self.resource_name = name
@@ -251,10 +219,9 @@ class ResourceDefinition:
         self.description = raw.get('description', '')
 
 
-class PayloadDefinition:
+class PayloadMeta:
     """Object containing metadata about a payload definition.
 
-    Supported fields are:
     """
     def __init__(self, name, raw):
         self.payload_name = name

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -140,9 +140,7 @@ class CharmMeta:
 
 
 class RelationMeta:
-    """Object containing metadata about a relation definition.
-
-    """
+    """Object containing metadata about a relation definition."""
     def __init__(self, role, relation_name, raw):
         self.role = role
         self.relation_name = relation_name
@@ -151,9 +149,7 @@ class RelationMeta:
 
 
 class StorageMeta:
-    """Object containing metadata about a storage definition.
-
-    """
+    """Object containing metadata about a storage definition."""
     def __init__(self, name, raw):
         self.storage_name = name
         self.type = raw['type']
@@ -173,9 +169,7 @@ class StorageMeta:
 
 
 class ResourceMeta:
-    """Object containing metadata about a resource definition.
-
-    """
+    """Object containing metadata about a resource definition."""
     def __init__(self, name, raw):
         self.resource_name = name
         self.type = raw['type']
@@ -184,9 +178,7 @@ class ResourceMeta:
 
 
 class PayloadMeta:
-    """Object containing metadata about a payload definition.
-
-    """
+    """Object containing metadata about a payload definition."""
     def __init__(self, name, raw):
         self.payload_name = name
         self.type = raw['type']

--- a/juju/framework.py
+++ b/juju/framework.py
@@ -226,12 +226,14 @@ class EventsBase(Object):
         """Return a mapping of event_kinds to bound_events for all available events.
         """
         events_map = {}
-        for event_kind in dir(type(self)):
-            # filter based on class attr value in case there are properties
-            # defined on subclasses to access sets of events, which could
-            # cause infinite recursion
-            unbound_event = getattr(type(self), event_kind)
+        for event_kind, unbound_event in type(self).__dict__.items():
+            # We have to filter based on the unbound_event (class attribute)
+            # rather than the bound_event (instance attribute) to allow for
+            # any instance properties which rely on this method (e.g., to
+            # present groups of events) which would lead to infinite recursion.
             if isinstance(unbound_event, Event):
+                # We actually care about the bound_event, however, since it
+                # provides the most info for users of this method.
                 bound_event = getattr(self, event_kind)
                 events_map[event_kind] = bound_event
         return events_map

--- a/juju/framework.py
+++ b/juju/framework.py
@@ -226,9 +226,13 @@ class EventsBase(Object):
         """Return a mapping of event_kinds to bound_events for all available events.
         """
         events_map = {}
-        for event_kind in dir(self):
-            bound_event = getattr(self, event_kind)
-            if isinstance(bound_event, BoundEvent):
+        for event_kind in dir(type(self)):
+            # filter based on class attr value in case there are properties
+            # defined on subclasses to access sets of events, which could
+            # cause infinite recursion
+            unbound_event = getattr(type(self), event_kind)
+            if isinstance(unbound_event, Event):
+                bound_event = getattr(self, event_kind)
                 events_map[event_kind] = bound_event
         return events_map
 

--- a/juju/main.py
+++ b/juju/main.py
@@ -120,7 +120,7 @@ def main():
     charm_state_path = charm_dir / CHARM_STATE_FILE
     framework = juju.framework.Framework(data_path=charm_state_path)
     try:
-        charm = charm_module.Charm(framework, None, _load_metadata())
+        charm = charm_module.Charm(framework, None, juju.charm.CharmMeta(_load_metadata()))
 
         # When a charm is force-upgraded and a unit is in an error state Juju does not run upgrade-charm and
         # instead runs the failed hook followed by config-changed. Given the nature of force-upgrading

--- a/test/charms/test_main/metadata.yaml
+++ b/test/charms/test_main/metadata.yaml
@@ -22,4 +22,4 @@ storage:
     disks:
         type: block
         multiple:
-        range: 0-
+            range: 0-

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -6,7 +6,7 @@ import shutil
 
 from pathlib import Path
 
-from juju.charm import CharmBase
+from juju.charm import CharmBase, CharmMetadata
 from juju.charm import CharmEvents
 from juju.framework import Framework
 
@@ -44,7 +44,7 @@ class TestCharm(unittest.TestCase):
                 self.started = True
 
         framework = self.create_framework()
-        charm = MyCharm(framework, None, {})
+        charm = MyCharm(framework, None, CharmMetadata())
         charm.on.start.emit()
 
         self.assertEqual(charm.started, True)
@@ -63,7 +63,7 @@ class TestCharm(unittest.TestCase):
             def on_any_relation(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
-        metadata = {
+        metadata = CharmMetadata({
             'name': 'my-charm',
             'requires': {
                 'req1': {'interface': 'req1'},
@@ -76,7 +76,7 @@ class TestCharm(unittest.TestCase):
             'peers': {
                 'peer1': {'interface': 'peer1'},
             },
-        }
+        })
 
         charm = MyCharm(self.create_framework(), None, metadata)
 
@@ -109,13 +109,13 @@ class TestCharm(unittest.TestCase):
             def on_stor2_storage_detaching(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
-        metadata = {
+        metadata = CharmMetadata({
             'name': 'my-charm',
             'storage': {
                 'stor1': {'type': 'filesystem'},
                 'stor2': {'type': 'filesystem'},
             },
-        }
+        })
 
         charm = MyCharm(self.create_framework(), None, metadata)
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -86,12 +86,15 @@ class TestCharm(unittest.TestCase):
         charm.on.pro1_relation_departed.emit()
         charm.on.peer1_relation_broken.emit()
 
+        charm.on.relation['req1'].joined.emit()
+
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
             'RelationChangedEvent',
             'RelationChangedEvent',
             'RelationDepartedEvent',
             'RelationBrokenEvent',
+            'RelationJoinedEvent',
         ])
 
     def test_storage_events(self):
@@ -122,9 +125,12 @@ class TestCharm(unittest.TestCase):
         charm.on.stor1_storage_attached.emit()
         charm.on.stor2_storage_detaching.emit()
 
+        charm.on.storage["stor1"].attached.emit()
+
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
             'StorageDetachingEvent',
+            'StorageAttachedEvent',
         ])
 
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -86,15 +86,12 @@ class TestCharm(unittest.TestCase):
         charm.on.pro1_relation_departed.emit()
         charm.on.peer1_relation_broken.emit()
 
-        charm.on.relation['req1'].joined.emit()
-
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
             'RelationChangedEvent',
             'RelationChangedEvent',
             'RelationDepartedEvent',
             'RelationBrokenEvent',
-            'RelationJoinedEvent',
         ])
 
     def test_storage_events(self):
@@ -147,12 +144,9 @@ class TestCharm(unittest.TestCase):
         charm.on.stor1_storage_attached.emit()
         charm.on.stor2_storage_detaching.emit()
 
-        charm.on.storage["stor1"].attached.emit()
-
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
             'StorageDetachingEvent',
-            'StorageAttachedEvent',
         ])
 
 


### PR DESCRIPTION
This adds the model classes to hold and represent the charm metadata information in a structured way.  It also adds helpers for looking up event groups by relation or storage name to enable more programmatic interaction with those events.