### PR TITLE
Add group views for relation and storage events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from juju.framework import Object, Event, EventBase, EventsBase
 
 
@@ -82,15 +83,31 @@ class CharmBase(Object):
         super().__init__(framework, key)
         self.metadata = metadata
 
+        # These are a per-relation group views of events, which are used for more programmatic access.
+        # For example: framework.observe(self.on.relation[db_rel].joined, self)
+        type(self.on).relation = {}
+        type(self.on).storage = {}
+
+        def _create_event_and_add_to_group(event_group_name, group_member_name, event_name, event_type):
+            event_group = getattr(self.on, event_group_name)
+            event_kind = f'{group_member_name}_{event_group_name}_{event_name}'
+            self.on.define_event(event_kind, event_type)
+            bound_event = getattr(self.on, event_kind)
+            setattr(event_group[group_member_name], event_name, bound_event)
+
         for relation_name in self.metadata.relations:
-            self.on.define_event(f'{relation_name}_relation_joined', RelationJoinedEvent)
-            self.on.define_event(f'{relation_name}_relation_changed', RelationChangedEvent)
-            self.on.define_event(f'{relation_name}_relation_departed', RelationDepartedEvent)
-            self.on.define_event(f'{relation_name}_relation_broken', RelationBrokenEvent)
+            self.on.relation[relation_name] = SimpleNamespace()
+            for event_name, event_type in {'joined': RelationJoinedEvent,
+                                           'changed': RelationChangedEvent,
+                                           'departed': RelationDepartedEvent,
+                                           'broken': RelationBrokenEvent}.items():
+                _create_event_and_add_to_group('relation', relation_name, event_name, event_type)
 
         for storage_name in metadata.storage:
-            self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
-            self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
+            self.on.storage[storage_name] = SimpleNamespace()
+            for event_name, event_type in {'attached': StorageAttachedEvent,
+                                           'detaching': StorageDetachingEvent}.items():
+                    _create_event_and_add_to_group('storage', storage_name, event_name, event_type)
 
 
 class CharmMeta:

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -86,12 +86,15 @@ class TestCharm(unittest.TestCase):
         charm.on.pro1_relation_departed.emit()
         charm.on.peer1_relation_broken.emit()
 
+        charm.on.relation['req1'].joined.emit()
+
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
             'RelationChangedEvent',
             'RelationChangedEvent',
             'RelationDepartedEvent',
             'RelationBrokenEvent',
+            'RelationJoinedEvent',
         ])
 
     def test_storage_events(self):
@@ -144,9 +147,12 @@ class TestCharm(unittest.TestCase):
         charm.on.stor1_storage_attached.emit()
         charm.on.stor2_storage_detaching.emit()
 
+        charm.on.storage['stor1'].attached.emit()
+
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
             'StorageDetachingEvent',
+            'StorageAttachedEvent',
         ])
 
 


### PR DESCRIPTION
This adds two group views for events, for relations and storage, which allow programmatic access to the events by relation or storage name. These would be use by Parts, e.g., InterfaceParts, which cannot know their name a priori.