### PR TITLE
Add missing hook to test charm

### DIFF
--- a/test/charms/test_main/hooks/disks-storage-attached
+++ b/test/charms/test_main/hooks/disks-storage-attached
@@ -1,0 +1,1 @@
+install


### PR DESCRIPTION
This was intended to be added in #6 but got missed.  However, the tests will auto-create it, allowing them to pass even when it's missing.  It is, in fact, expected to be in place, though.