### PR TITLE
Use underscores when defining events

### DIFF
--- a/juju/framework.py
+++ b/juju/framework.py
@@ -218,6 +218,13 @@ class EventsBase(Object):
 
     @classmethod
     def define_event(cls, event_kind, event_type):
+        """Define an event on this type at runtime.
+
+        cls -- a type to define an event on.
+        event_kind -- an attribute name that will be used to access the event. Dashes will be converted to underscores.
+        event_type -- a type of the event to define.
+        """
+        event_kind = event_kind.replace('-', '_')
         event_descriptor = Event(event_type)
         event_descriptor.__set_name__(cls, event_kind)
         setattr(cls, event_kind, event_descriptor)

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -67,14 +67,15 @@ class TestCharm(unittest.TestCase):
             'name': 'my-charm',
             'requires': {
                 'req1': {'interface': 'req1'},
-                'req2': {'interface': 'req2'},
+                'req-2': {'interface': 'req2'},
             },
             'provides': {
                 'pro1': {'interface': 'pro1'},
-                'pro2': {'interface': 'pro2'},
+                'pro-2': {'interface': 'pro2'},
             },
             'peers': {
                 'peer1': {'interface': 'peer1'},
+                'peer-2': {'interface': 'peer2'},
             },
         })
 
@@ -82,15 +83,19 @@ class TestCharm(unittest.TestCase):
 
         charm.on.req1_relation_joined.emit()
         charm.on.req1_relation_changed.emit()
-        charm.on.req2_relation_changed.emit()
+        charm.on.req_2_relation_changed.emit()
         charm.on.pro1_relation_departed.emit()
+        charm.on.pro_2_relation_departed.emit()
         charm.on.peer1_relation_broken.emit()
+        charm.on.peer_2_relation_broken.emit()
 
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
             'RelationChangedEvent',
             'RelationChangedEvent',
             'RelationDepartedEvent',
+            'RelationDepartedEvent',
+            'RelationBrokenEvent',
             'RelationBrokenEvent',
         ])
 
@@ -102,11 +107,19 @@ class TestCharm(unittest.TestCase):
                 self.seen = []
                 framework.observe(self.on.stor1_storage_attached, self)
                 framework.observe(self.on.stor2_storage_detaching, self)
+                framework.observe(self.on.stor3_storage_attached, self)
+                framework.observe(self.on.stor_4_storage_attached, self)
 
             def on_stor1_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
             def on_stor2_storage_detaching(self, event):
+                self.seen.append(f'{type(event).__name__}')
+
+            def on_stor3_storage_attached(self, event):
+                self.seen.append(f'{type(event).__name__}')
+
+            def on_stor_4_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
         metadata = CharmMeta({
@@ -125,7 +138,7 @@ class TestCharm(unittest.TestCase):
                         'range': '2-',
                     },
                 },
-                'stor4': {
+                'stor-4': {
                     'type': 'filesystem',
                     'multiple': {
                         'range': '2-4',
@@ -137,16 +150,20 @@ class TestCharm(unittest.TestCase):
         self.assertIsNone(metadata.storage['stor1'].multiple_range)
         self.assertEqual(metadata.storage['stor2'].multiple_range, (2, 2))
         self.assertEqual(metadata.storage['stor3'].multiple_range, (2, None))
-        self.assertEqual(metadata.storage['stor4'].multiple_range, (2, 4))
+        self.assertEqual(metadata.storage['stor-4'].multiple_range, (2, 4))
 
         charm = MyCharm(self.create_framework(), None, metadata)
 
         charm.on.stor1_storage_attached.emit()
         charm.on.stor2_storage_detaching.emit()
+        charm.on.stor3_storage_attached.emit()
+        charm.on.stor_4_storage_attached.emit()
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
             'StorageDetachingEvent',
+            'StorageAttachedEvent',
+            'StorageAttachedEvent',
         ])
 
 


### PR DESCRIPTION
In order to be able to access events via attributes, dashes need to be
converted to underscores in relation and storage endpoint names.