### PR TITLE
Use underscores when defining events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -83,12 +83,14 @@ class CharmBase(Object):
         self.metadata = metadata
 
         for relation_name in self.metadata.relations:
+            relation_name = relation_name.replace('-', '_')
             self.on.define_event(f'{relation_name}_relation_joined', RelationJoinedEvent)
             self.on.define_event(f'{relation_name}_relation_changed', RelationChangedEvent)
             self.on.define_event(f'{relation_name}_relation_departed', RelationDepartedEvent)
             self.on.define_event(f'{relation_name}_relation_broken', RelationBrokenEvent)
 
         for storage_name in metadata.storage:
+            storage_name = storage_name.replace('-', '_')
             self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
             self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -67,14 +67,15 @@ class TestCharm(unittest.TestCase):
             'name': 'my-charm',
             'requires': {
                 'req1': {'interface': 'req1'},
-                'req2': {'interface': 'req2'},
+                'req-2': {'interface': 'req2'},
             },
             'provides': {
                 'pro1': {'interface': 'pro1'},
-                'pro2': {'interface': 'pro2'},
+                'pro-2': {'interface': 'pro2'},
             },
             'peers': {
                 'peer1': {'interface': 'peer1'},
+                'peer-2': {'interface': 'peer2'},
             },
         })
 
@@ -82,15 +83,19 @@ class TestCharm(unittest.TestCase):
 
         charm.on.req1_relation_joined.emit()
         charm.on.req1_relation_changed.emit()
-        charm.on.req2_relation_changed.emit()
+        charm.on.req_2_relation_changed.emit()
         charm.on.pro1_relation_departed.emit()
+        charm.on.pro_2_relation_departed.emit()
         charm.on.peer1_relation_broken.emit()
+        charm.on.peer_2_relation_broken.emit()
 
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
             'RelationChangedEvent',
             'RelationChangedEvent',
             'RelationDepartedEvent',
+            'RelationDepartedEvent',
+            'RelationBrokenEvent',
             'RelationBrokenEvent',
         ])
 
@@ -102,11 +107,19 @@ class TestCharm(unittest.TestCase):
                 self.seen = []
                 framework.observe(self.on.stor1_storage_attached, self)
                 framework.observe(self.on.stor2_storage_detaching, self)
+                framework.observe(self.on.stor3_storage_attached, self)
+                framework.observe(self.on.stor_4_storage_attached, self)
 
             def on_stor1_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
             def on_stor2_storage_detaching(self, event):
+                self.seen.append(f'{type(event).__name__}')
+
+            def on_stor3_storage_attached(self, event):
+                self.seen.append(f'{type(event).__name__}')
+
+            def on_stor_4_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
         metadata = CharmMeta({
@@ -125,7 +138,7 @@ class TestCharm(unittest.TestCase):
                         'range': '2-',
                     },
                 },
-                'stor4': {
+                'stor-4': {
                     'type': 'filesystem',
                     'multiple': {
                         'range': '2-4',
@@ -137,16 +150,20 @@ class TestCharm(unittest.TestCase):
         self.assertIsNone(metadata.storage['stor1'].multiple_range)
         self.assertEqual(metadata.storage['stor2'].multiple_range, (2, 2))
         self.assertEqual(metadata.storage['stor3'].multiple_range, (2, None))
-        self.assertEqual(metadata.storage['stor4'].multiple_range, (2, 4))
+        self.assertEqual(metadata.storage['stor-4'].multiple_range, (2, 4))
 
         charm = MyCharm(self.create_framework(), None, metadata)
 
         charm.on.stor1_storage_attached.emit()
         charm.on.stor2_storage_detaching.emit()
+        charm.on.stor3_storage_attached.emit()
+        charm.on.stor_4_storage_attached.emit()
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
             'StorageDetachingEvent',
+            'StorageAttachedEvent',
+            'StorageAttachedEvent',
         ])
 
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -417,6 +417,12 @@ class TestFramework(unittest.TestCase):
         class MyBar(EventBase):
             pass
 
+        class DeadBeefEvent(EventBase):
+            pass
+
+        class NoneEvent(EventBase):
+            pass
+
         pub.on_a.define_event("foo", MyFoo)
         pub.on_b.define_event("bar", MyBar)
 
@@ -431,6 +437,18 @@ class TestFramework(unittest.TestCase):
         # Definitions remained local to the specific type.
         self.assertRaises(AttributeError, lambda: pub.on_a.bar)
         self.assertRaises(AttributeError, lambda: pub.on_b.foo)
+
+        # Try to use an event name which is not a valid python identifier.
+        with self.assertRaises(RuntimeError):
+            pub.on_a.define_event("dead-beef", DeadBeefEvent)
+
+        # Try to use a python keyword for an event name.
+        with self.assertRaises(RuntimeError):
+            pub.on_a.define_event("None", NoneEvent)
+
+        # Try to override an existing attribute.
+        with self.assertRaises(RuntimeError):
+            pub.on_a.define_event("foo", MyFoo)
 
 
 class TestStoredState(unittest.TestCase):


### PR DESCRIPTION
In order to be able to access events via attributes, dashes need to be
converted to underscores in relation and storage endpoint names.

Moreover, define_event should check to make sure that event_kind is a
valid identifier, not a keyword and does not override an existing
attribute.