### PR TITLE
Ensure that hook symlinks are only created for hook events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,45 +1,42 @@
 from juju.framework import Object, Event, EventBase, EventsBase
 
 
-class JujuEvent(EventBase):
-    pass
-
-class JujuHookEvent(EventBase):
+class HookEvent(EventBase):
     pass
 
 
-class InstallEvent(JujuHookEvent):
+class InstallEvent(HookEvent):
     pass
 
-class StartEvent(JujuHookEvent):
+class StartEvent(HookEvent):
     pass
 
-class StopEvent(JujuHookEvent):
+class StopEvent(HookEvent):
     pass
 
-class ConfigChangedEvent(JujuHookEvent):
+class ConfigChangedEvent(HookEvent):
     pass
 
-class UpdateStatusEvent(JujuHookEvent):
+class UpdateStatusEvent(HookEvent):
     pass
 
-class UpgradeCharmEvent(JujuHookEvent):
+class UpgradeCharmEvent(HookEvent):
     pass
 
-class PreSeriesUpgradeEvent(JujuHookEvent):
+class PreSeriesUpgradeEvent(HookEvent):
     pass
 
-class PostSeriesUpgradeEvent(JujuHookEvent):
+class PostSeriesUpgradeEvent(HookEvent):
     pass
 
-class LeaderElectedEvent(JujuHookEvent):
+class LeaderElectedEvent(HookEvent):
     pass
 
-class LeaderSettingsChangedEvent(JujuHookEvent):
+class LeaderSettingsChangedEvent(HookEvent):
     pass
 
 
-class RelationEvent(JujuHookEvent):
+class RelationEvent(HookEvent):
     pass
 
 
@@ -56,7 +53,7 @@ class RelationBrokenEvent(RelationEvent):
     pass
 
 
-class StorageEvent(JujuHookEvent):
+class StorageEvent(HookEvent):
     pass
 
 

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,62 +1,69 @@
 from juju.framework import Object, Event, EventBase, EventsBase
 
 
-class InstallEvent(EventBase):
+class JujuEvent(EventBase):
     pass
 
-class StartEvent(EventBase):
-    pass
-
-class StopEvent(EventBase):
-    pass
-
-class ConfigChangedEvent(EventBase):
-    pass
-
-class UpdateStatusEvent(EventBase):
-    pass
-
-class UpgradeCharmEvent(EventBase):
-    pass
-
-class PreSeriesUpgradeEvent(EventBase):
-    pass
-
-class PostSeriesUpgradeEvent(EventBase):
-    pass
-
-class LeaderElectedEvent(EventBase):
-    pass
-
-class LeaderSettingsChangedEvent(EventBase):
+class JujuHookEvent(EventBase):
     pass
 
 
-class RelationEventBase(EventBase):
+class InstallEvent(JujuHookEvent):
+    pass
+
+class StartEvent(JujuHookEvent):
+    pass
+
+class StopEvent(JujuHookEvent):
+    pass
+
+class ConfigChangedEvent(JujuHookEvent):
+    pass
+
+class UpdateStatusEvent(JujuHookEvent):
+    pass
+
+class UpgradeCharmEvent(JujuHookEvent):
+    pass
+
+class PreSeriesUpgradeEvent(JujuHookEvent):
+    pass
+
+class PostSeriesUpgradeEvent(JujuHookEvent):
+    pass
+
+class LeaderElectedEvent(JujuHookEvent):
+    pass
+
+class LeaderSettingsChangedEvent(JujuHookEvent):
     pass
 
 
-class RelationJoinedEvent(RelationEventBase):
-    pass
-
-class RelationChangedEvent(RelationEventBase):
-    pass
-
-class RelationDepartedEvent(RelationEventBase):
-    pass
-
-class RelationBrokenEvent(RelationEventBase):
+class RelationEvent(JujuHookEvent):
     pass
 
 
-class StorageEventBase(EventBase):
+class RelationJoinedEvent(RelationEvent):
+    pass
+
+class RelationChangedEvent(RelationEvent):
+    pass
+
+class RelationDepartedEvent(RelationEvent):
+    pass
+
+class RelationBrokenEvent(RelationEvent):
     pass
 
 
-class StorageAttachedEvent(StorageEventBase):
+class StorageEvent(JujuHookEvent):
     pass
 
-class StorageDetachingEvent(StorageEventBase):
+
+class StorageAttachedEvent(StorageEvent):
+    pass
+
+class StorageDetachingEvent(StorageEvent):
     pass
 
 

--- a/juju/main.py
+++ b/juju/main.py
@@ -80,13 +80,11 @@ def _setup_hooks(charm_dir, charm):
     charm_dir -- A root directory of the charm.
     charm -- An instance of the Charm class.
     """
-    from juju.charm import JujuHookEvent
+    from juju.charm import HookEvent
 
-    def is_hook_event(bound_event):
-        return issubclass(bound_event.event_type, JujuHookEvent)
-
-    for bound_event in filter(is_hook_event, charm.on.events().values()):
-        _handle_event_link(charm_dir, bound_event)
+    for bound_event in charm.on.events().values():
+        if issubclass(bound_event.event_type, HookEvent):
+            _handle_event_link(charm_dir, bound_event)
 
 
 def _emit_charm_event(charm, event_name):

--- a/juju/main.py
+++ b/juju/main.py
@@ -32,7 +32,7 @@ def _handle_event_link(charm_dir, bound_event):
     """Create a symlink for a particular event.
 
     charm_dir -- A root directory of the charm
-    event_name -- A name of the event for which to create a symlink.
+    bound_event -- An event for which to create a symlink.
     """
     from juju.charm import InstallEvent
 


### PR DESCRIPTION
Split out from #16 for independent review. This uses classes to allow filtering events based on their type rather than name, and uses that filtering to ensure that symlinks are created only for hook events, rather than for charm-defined custom events.