### PR TITLE
Implement _from_iterable for StoredSet

### DIFF
--- a/juju/framework.py
+++ b/juju/framework.py
@@ -723,3 +723,14 @@ class StoredSet(collections.MutableSet):
 
     def __len__(self):
         return len(self._under)
+
+    @classmethod
+    def _from_iterable(cls, it):
+        """Construct an instance of the class from any iterable input.
+
+        Per https://docs.python.org/3/library/collections.abc.html
+        if the Set mixin is being used in a class with a different constructor signature,
+        you will need to override _from_iterable() with a classmethod that can construct
+        new instances from an iterable argument.
+        """
+        return set(it)


### PR DESCRIPTION
Sets are a bit special because they provide operations that generate
completely new sets instead of modifying the existing ones in-place:

* difference;
* symmetric_difference;
* union;
* intersection;
* copy (not present in MutableSet, only in built-in sets).

All of those operations return a new set object and rely on
_from_iterable classmethod defined on MutableSet to provide a new
instance of a class that derives from MutableSet based on an iterable.

StoredSet extends the signature of the __init__ function with an
additional argument (stored_data) and thus the library implementation of
_from_iterable fails to instantiate a new StoredSet.

Moreover, for the case where a binary operation * is performed with s1
as a StoredSet and s2 is a built-in set, the expected result is that a
new built-in set will be returned because a new object created as a
result of the operation should not be bound from the framework
perspective.

s1 * s2 -> set()

where * can be one of the set operations (&, |, ^, -).

Documentation reference:

https://docs.python.org/3/library/collections.abc.html
"The class constructor is assumed to have a signature in the form
ClassName(iterable). That assumption is factored-out to an internal
classmethod called _from_iterable() which calls cls(iterable) to produce
a new set. If the Set mixin is being used in a class with a different
constructor signature, you will need to override _from_iterable() with a
classmethod that can construct new instances from an iterable argument."