### PR TITLE
Add support for mutable relation data

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -118,11 +118,11 @@ class Relation:
 
     @property
     def apps(self):
-        return list(self._apps)
+        return self._apps
 
     @property
     def units(self):
-        return list(self._units)
+        return self._units
 
 
 class RelationData(Mapping):

--- a/juju/model.py
+++ b/juju/model.py
@@ -207,7 +207,10 @@ class RelationDataError(ModelError):
 
 class ModelBackend:
     def _run(self, *args):
-        return json.loads(run(args + ('--format=json',), stdout=PIPE, check=True).stdout.decode('utf8'))
+        result = run(args + ('--format=json',), stdout=PIPE, check=True)
+        text = result.stdout.decode('utf8')
+        data = json.loads(text)
+        return data
 
     def _run_no_output(self, *args):
         run(args, check=True)

--- a/juju/model.py
+++ b/juju/model.py
@@ -108,32 +108,21 @@ class Relation:
     def __init__(self, relation_name, relation_id, local_unit, backend, cache):
         self.relation_name = relation_name
         self.relation_id = relation_id
-        self._local_unit = local_unit
-        self._backend = backend
-        self._cache = cache
-        self._apps = None
-        self._units = None
-        self._data = None
+        self._apps = set()
+        self._units = []
+        for unit_name in backend.relation_list(relation_id):
+            unit = cache.get(Unit, unit_name)
+            self._units.append(unit)
+            self._apps.add(unit.app)
+        self.data = RelationData(relation_name, relation_id, local_unit, self.units, backend)
 
     @property
     def apps(self):
-        if self._apps is None:
-            self._apps = list({unit.app for unit in self.units})
-        return self._apps
+        return list(self._apps)
 
     @property
     def units(self):
-        if self._units is None:
-            self._units = []
-            for unit_name in self._backend.relation_list(self.relation_id):
-                self._units.append(self._cache.get(Unit, unit_name))
-        return self._units
-
-    @property
-    def data(self):
-        if self._data is None:
-            self._data = RelationData(self.relation_name, self.relation_id, self._local_unit, self.units, self._backend)
-        return self._data
+        return list(self._units)
 
 
 class RelationData(Mapping):

--- a/juju/model.py
+++ b/juju/model.py
@@ -162,9 +162,9 @@ class RelationUnitData(LazyMapping, MutableMapping):
 
     def __setitem__(self, key, value):
         if not self._is_mutable:
-            raise TypeError(f'Cannot set relation data for {self.unit.name}')
+            raise RelationDataError(f'cannot set relation data for {self.unit.name}')
         if not isinstance(value, str):
-            raise TypeError('Relation data values must be strings')
+            raise RelationDataError('relation data values must be strings')
         self._backend.relation_set(self.relation_id, key, value)
         # Don't load data unnecessarily if we're only updating.
         if self._lazy_data is not None:
@@ -199,6 +199,10 @@ class TooManyRelatedApps(ModelError):
         self.relation_name = relation_name
         self.num_related = num_related
         self.max_supported = max_supported
+
+
+class RelationDataError(ModelError):
+    pass
 
 
 class ModelBackend:

--- a/juju/model.py
+++ b/juju/model.py
@@ -254,7 +254,7 @@ class ModelBackend:
         return self._run('relation-get', '-r', relation_id, '-', member_name)
 
     def relation_set(self, relation_id, key, value):
-        return self._run_no_output('relation-set', '-r', relation_id, f'{key}={value or ""}')
+        return self._run_no_output('relation-set', '-r', relation_id, f'{key}={value}')
 
     def config_get(self):
         return self._run('config-get')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -5,8 +5,10 @@ import unittest
 import juju.model
 
 
-# TODO: It would be better if this implemented these as executables that were called
-# via the actual juju.model.ModelBackend implementation.
+# TODO: We need some manner of test to validate the actual ModelBackend implementation, round-tripped
+# through the actual subprocess calls. Either this class could implement these functions as executables
+# that were called via subprocess, or more simple tests that just test through ModelBackend while leaving
+# these tests alone, depending on what proves easier.
 class TestModelBackend:
     def __init__(self):
         self.relation_set_calls = []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -5,6 +5,8 @@ import unittest
 import juju.model
 
 
+# TODO: It would be better if this implemented these as executables that were called
+# via the actual juju.model.ModelBackend implementation.
 class TestModelBackend:
     def __init__(self):
         self.relation_set_calls = []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -53,42 +53,55 @@ class TestModel(unittest.TestCase):
     def setUp(self):
         self.model = juju.model.Model('myapp/0', ['db0', 'db1', 'db2'], TestModelBackend())
 
-    def test_relations(self):
+    def test_model(self):
         self.assertIs(self.model.app, self.model.unit.app)
+
+    def test_relations_keys(self):
         for relation in self.model.relations['db2']:
             self.assertIn(self.model.unit, relation.data)
             unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
             self.assertIs(self.model.unit, unit_from_rel)
+
+    def test_relation_helper(self):
         self.assertIsNone(self.model.relation('db0'))
         self.assertIsInstance(self.model.relation('db1'), juju.model.Relation)
         with self.assertRaises(juju.model.TooManyRelatedApps):
             self.model.relation('db2')
+
+    def test_relation_data(self):
         random_unit = self.model._cache.get(juju.model.Unit, 'randomunit/0')
         with self.assertRaises(KeyError):
             self.model.relation('db1').data[random_unit]
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.relation('db1').units))
         self.assertEqual(self.model.relation('db1').data[remoteapp1_0], {'host': 'remoteapp1-0'})
+
+    def test_relation_data_modify_remote(self):
         rel_db1 = self.model.relation('db1')
         backend = self.model._backend
-        # Verify that we can't modify relation data for other units.
+        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.relation('db1').units))
         with self.assertRaises(TypeError):
             rel_db1.data[remoteapp1_0]['foo'] = 'bar'
         self.assertFalse(backend.relation_set_called)
-        # Force the relation data for the local unit to be read into memory. We have to do this because
-        # our fake relation_get doesn't honor values previously set by relation_set like the real Juju
-        # hook commands would.
-        self.assertNotIn('foo', rel_db1.data[self.model.unit])
-        # Verify that we can modify our own relation data.
-        rel_db1.data[self.model.unit]['foo'] = 'bar'
+
+    def test_relation_data_modify_local(self):
+        rel_db1 = self.model.relation('db1')
+        backend = self.model._backend
+        self.assertIn('host', rel_db1.data[self.model.unit])
+        rel_db1.data[self.model.unit]['host'] = 'bar'
         self.assertTrue(backend.relation_set_called)
-        self.assertEqual(rel_db1.data[self.model.unit]['foo'], 'bar')
-        backend.relation_set_called = False
-        # Verify that we can delete relation keys.
-        del rel_db1.data[self.model.unit]['foo']
+        self.assertEqual(rel_db1.data[self.model.unit]['host'], 'bar')
+
+    def test_relation_data_del_key(self):
+        rel_db1 = self.model.relation('db1')
+        backend = self.model._backend
+        self.assertIn('host', rel_db1.data[self.model.unit])
+        del rel_db1.data[self.model.unit]['host']
         self.assertTrue(backend.relation_set_called)
-        self.assertNotIn('foo', rel_db1.data[self.model.unit])
-        backend.relation_set_called = False
-        # Verify that relation data values are type-checked as strings.
+        self.assertNotIn('host', rel_db1.data[self.model.unit])
+
+    def test_relation_data_type_check(self):
+        rel_db1 = self.model.relation('db1')
+        backend = self.model._backend
         with self.assertRaises(TypeError):
             rel_db1.data[self.model.unit]['foo'] = 1
         with self.assertRaises(TypeError):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -82,7 +82,7 @@ class TestModel(unittest.TestCase):
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.relation('db1').units))
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[remoteapp1_0])
-        with self.assertRaises(TypeError):
+        with self.assertRaises(juju.model.RelationDataError):
             rel_db1.data[remoteapp1_0]['foo'] = 'bar'
         self.assertFalse(self.backend.relation_set_called)
         self.assertNotIn('foo', rel_db1.data[remoteapp1_0])
@@ -117,11 +117,11 @@ class TestModel(unittest.TestCase):
 
     def test_relation_data_type_check(self):
         rel_db1 = self.model.relation('db1')
-        with self.assertRaises(TypeError):
+        with self.assertRaises(juju.model.RelationDataError):
             rel_db1.data[self.model.unit]['foo'] = 1
-        with self.assertRaises(TypeError):
+        with self.assertRaises(juju.model.RelationDataError):
             rel_db1.data[self.model.unit]['foo'] = {'foo': 'bar'}
-        with self.assertRaises(TypeError):
+        with self.assertRaises(juju.model.RelationDataError):
             rel_db1.data[self.model.unit]['foo'] = None
         self.assertFalse(self.backend.relation_set_called)
 


### PR DESCRIPTION
Relation data for the local unit can be changed, which are translated into calls to `relation-set`. This ensures that remote unit relation data cannot be modified and that the in-memory cache of relation data is kept in sync with updated values.