### PR TITLE
Implement comparison operators for stored types

### DIFF
--- a/juju/framework.py
+++ b/juju/framework.py
@@ -679,6 +679,14 @@ class StoredDict(collections.MutableMapping):
     def __len__(self):
         return len(self._under)
 
+    def __eq__(self, other):
+        if isinstance(other, StoredDict):
+            return self._under == other._under
+        elif isinstance(other, collections.abc.Mapping):
+            return self._under == other
+        else:
+            return NotImplemented
+
 
 class StoredList(collections.MutableSequence):
 
@@ -703,6 +711,46 @@ class StoredList(collections.MutableSequence):
 
     def append(self, value):
         self._under.append(value)
+
+    def __eq__(self, other):
+        if isinstance(other, StoredList):
+            return self._under == other._under
+        elif isinstance(other, collections.abc.Sequence):
+            return self._under == other
+        else:
+            return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, StoredList):
+            return self._under < other._under
+        elif isinstance(other, collections.abc.Sequence):
+            return self._under < other
+        else:
+            return NotImplemented
+
+    def __le__(self, other):
+        if isinstance(other, StoredList):
+            return self._under <= other._under
+        elif isinstance(other, collections.abc.Sequence):
+            return self._under <= other
+        else:
+            return NotImplemented
+
+    def __gt__(self, other):
+        if isinstance(other, StoredList):
+            return self._under > other._under
+        elif isinstance(other, collections.abc.Sequence):
+            return self._under > other
+        else:
+            return NotImplemented
+
+    def __ge__(self, other):
+        if isinstance(other, StoredList):
+            return self._under >= other._under
+        elif isinstance(other, collections.abc.Sequence):
+            return self._under >= other
+        else:
+            return NotImplemented
 
 
 class StoredSet(collections.MutableSet):
@@ -736,3 +784,27 @@ class StoredSet(collections.MutableSet):
         new instances from an iterable argument.
         """
         return set(it)
+
+    def __le__(self, other):
+        if isinstance(other, StoredSet):
+            return self._under <= other._under
+        elif isinstance(other, collections.abc.Set):
+            return self._under <= other
+        else:
+            return NotImplemented
+
+    def __ge__(self, other):
+        if isinstance(other, StoredSet):
+            return self._under >= other._under
+        elif isinstance(other, collections.abc.Set):
+            return self._under >= other
+        else:
+            return NotImplemented
+
+    def __eq__(self, other):
+        if isinstance(other, StoredSet):
+            return self._under == other._under
+        elif isinstance(other, collections.abc.Set):
+            return self._under == other
+        else:
+            return NotImplemented

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -516,9 +516,6 @@ class TestStoredState(unittest.TestCase):
         class SomeObject(Object):
             state = StoredState()
 
-            def __init__(self, parent, key):
-                super().__init__(parent, key)
-
         obj = SomeObject(framework, "1")
 
         try:
@@ -559,9 +556,6 @@ class TestStoredState(unittest.TestCase):
 
         class SomeObject(Object):
             state = StoredState()
-
-            def __init__(self, framework, key):
-                super().__init__(framework, key)
 
         obj = SomeObject(framework, "1")
         try:
@@ -612,13 +606,106 @@ class TestStoredState(unittest.TestCase):
 
             framework_copy.commit()
 
-    def test_set_operations(self):
+    def test_comparison_operations(self):
+        test_operations = [(
+            {"1"},               # Operand A.
+            {"1", "2"},          # Operand B.
+            lambda a, b: a < b,  # Operation to test.
+            True,                # Result of op(A, B).
+            False,               # Result of op(B, A).
+        ), (
+            {"1"},
+            {"1", "2"},
+            lambda a, b: a > b,
+            False,
+            True
+        ), (
+            # Empty set comparison.
+            set(),
+            set(),
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            {"a", "c"},
+            {"c", "a"},
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            dict(),
+            dict(),
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            {"1": "2"},
+            {"1": "2"},
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            {"1": "2"},
+            {"1": "3"},
+            lambda a, b: a == b,
+            False,
+            False
+        ), (
+            [],
+            [],
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            [1, 2],
+            [1, 2],
+            lambda a, b: a == b,
+            True,
+            True
+        ), (
+            [1, 2, 5, 6],
+            [1, 2, 5, 8, 10],
+            lambda a, b: a <= b,
+            True,
+            False
+        ), (
+            [1, 2, 5, 6],
+            [1, 2, 5, 8, 10],
+            lambda a, b: a < b,
+            True,
+            False
+        ), (
+            [1, 2, 5, 8],
+            [1, 2, 5, 6, 10],
+            lambda a, b: a > b,
+            True,
+            False
+        ), (
+            [1, 2, 5, 8],
+            [1, 2, 5, 6, 10],
+            lambda a, b: a >= b,
+            True,
+            False
+        ), (
+            [1, 2, 5, 8],
+            [1, 2, 5, 6, 10],
+            lambda a, b: a <= b,
+            False,
+            True
+        )]
+
         class SomeObject(Object):
             state = StoredState()
 
-            def __init__(self, framework, key):
-                super().__init__(framework, key)
+        framework = self.create_framework()
 
+        for a, b, op, op_ab, op_ba in test_operations:
+            obj = SomeObject(framework, "1")
+            obj.state.a = a
+            self.assertEqual(op(obj.state.a, b), op_ab)
+            self.assertEqual(op(b, obj.state.a), op_ba)
+
+    def test_set_operations(self):
         test_operations = [(
             {"1"},  # A set to test an operation against (other_set).
             lambda a, b: a | b,  # An operation to test.
@@ -645,6 +732,9 @@ class TestStoredState(unittest.TestCase):
             {"a", "b"},
             set()
         )]
+
+        class SomeObject(Object):
+            state = StoredState()
 
         framework = self.create_framework()
 


### PR DESCRIPTION
* dict comparison works based on the abstract implementation that
  compares items;
* for sets, `__eq__` has an abstract implementation based on `__le__`
  and https://docs.python.org/3/library/collections.abc.html documents
  that `__le__` and `__ge__` both need to be implemented to make other
  operations work. Lib/_collections_abc.py in cpython reveals that they
  `__le__` and `__ge__` do not depend on each other and so need to be
  reimplemented separately;
* for lists, besides `__eq__`, there are also other comparison
  operations that need to be implemented for lexicographical comparison.
  https://docs.python.org/3/tutorial/datastructures.html#comparing-sequences-and-other-types