### PR TITLE
Add relation and unit instances to relation events

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -48,7 +48,7 @@ class RelationEvent(HookEvent):
         }
 
     def restore(self, snapshot):
-        self.relation = self.framework.model.relation_by_id(snapshot['relation_name'], snapshot['relation_id'])
+        self.relation = self.framework.model.get_relation_by_id(snapshot['relation_name'], snapshot['relation_id'])
 
 class RelationUnitEvent(RelationEvent):
     def __init__(self, handle, relation, unit):

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -37,16 +37,40 @@ class LeaderSettingsChangedEvent(HookEvent):
 
 
 class RelationEvent(HookEvent):
+    def __init__(self, handle, relation):
+        super().__init__(handle)
+        self.relation = relation
+
+    def snapshot(self):
+        return {
+            'relation_name': self.relation.relation_name,
+            'relation_id': self.relation.relation_id,
+        }
+
+    def restore(self, snapshot):
+        self.relation = self.framework.model.relation_by_id(snapshot['relation_name'], snapshot['relation_id'])
+
+class RelationUnitEvent(RelationEvent):
+    def __init__(self, handle, relation, unit):
+        super().__init__(handle, relation)
+        self.unit = unit
+
+    def snapshot(self):
+        snapshot = super().snapshot()
+        snapshot['unit_name'] = self.unit.name
+        return snapshot
+
+    def restore(self, snapshot):
+        super().restore(snapshot)
+        self.unit = self.framework.model.get_unit(snapshot['unit_name'])
+
+class RelationJoinedEvent(RelationUnitEvent):
     pass
 
-
-class RelationJoinedEvent(RelationEvent):
+class RelationChangedEvent(RelationUnitEvent):
     pass
 
-class RelationChangedEvent(RelationEvent):
-    pass
-
-class RelationDepartedEvent(RelationEvent):
+class RelationDepartedEvent(RelationUnitEvent):
     pass
 
 class RelationBrokenEvent(RelationEvent):
@@ -55,7 +79,6 @@ class RelationBrokenEvent(RelationEvent):
 
 class StorageEvent(HookEvent):
     pass
-
 
 class StorageAttachedEvent(StorageEvent):
     pass

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -48,7 +48,7 @@ class RelationEvent(HookEvent):
         }
 
     def restore(self, snapshot):
-        self.relation = self.framework.model.get_relation_by_id(snapshot['relation_name'], snapshot['relation_id'])
+        self.relation = self.framework.model.get_relation(snapshot['relation_name'], snapshot['relation_id'])
 
 class RelationUnitEvent(RelationEvent):
     def __init__(self, handle, relation, unit):

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -43,8 +43,8 @@ class RelationEvent(HookEvent):
 
     def snapshot(self):
         return {
-            'relation_name': self.relation.relation_name,
-            'relation_id': self.relation.relation_id,
+            'relation_name': self.relation.name,
+            'relation_id': self.relation.id,
         }
 
     def restore(self, snapshot):

--- a/juju/main.py
+++ b/juju/main.py
@@ -115,8 +115,8 @@ def _get_event_args(charm, bound_event):
     model = charm.framework.model
     if issubclass(event_type, juju.charm.RelationEvent):
         relation_name = os.environ['JUJU_RELATION']
-        relation_id = os.environ['JUJU_RELATION_ID']
-        relation = model.get_relation_by_id(relation_name, relation_id)
+        relation_id = int(os.environ['JUJU_RELATION_ID'].split(':')[-1])
+        relation = model.get_relation(relation_name, relation_id)
         if issubclass(event_type, juju.charm.RelationUnitEvent):
             remote_unit_name = os.environ['JUJU_REMOTE_UNIT']
             remote_unit = model.get_unit(remote_unit_name)

--- a/juju/main.py
+++ b/juju/main.py
@@ -116,7 +116,7 @@ def _get_event_args(charm, bound_event):
     if issubclass(event_type, juju.charm.RelationEvent):
         relation_name = os.environ['JUJU_RELATION']
         relation_id = os.environ['JUJU_RELATION_ID']
-        relation = model.relation_by_id(relation_name, relation_id)
+        relation = model.get_relation_by_id(relation_name, relation_id)
         if issubclass(event_type, juju.charm.RelationUnitEvent):
             remote_unit_name = os.environ['JUJU_REMOTE_UNIT']
             remote_unit = model.get_unit(remote_unit_name)

--- a/juju/model.py
+++ b/juju/model.py
@@ -25,7 +25,7 @@ class Model:
         """
         if relation_id is not None:
             if not isinstance(relation_id, int):
-                raise ModelError(f'relation id {relation_id} must be an integer')
+                raise ModelError(f'relation id {relation_id} must be an int not {type(relation_id).__name__}')
             for relation in self.relations[relation_name]:
                 if relation.id == relation_id:
                     return relation
@@ -146,7 +146,7 @@ class Relation:
 class DeadRelation(Relation):
     def __init__(self, relation_name, relation_id):
         self.name = relation_name
-        self.id = int(relation_id.split(':')[-1]) if isinstance(relation_id, str) else relation_id
+        self.id = relation_id
         self.apps = set()
         self.units = set()
         self.data = RelationData(self, None, None)

--- a/juju/model.py
+++ b/juju/model.py
@@ -14,7 +14,7 @@ class Model:
         self.relations = RelationMapping(relation_names, self.unit, self._backend, self._cache)
         self.config = ConfigData(self._backend)
 
-    def relation(self, relation_name):
+    def get_relation(self, relation_name):
         """Return the single Relation object for the named relation, or None.
 
         This convenience method returns None if the relation is not established, or the
@@ -31,7 +31,7 @@ class Model:
             # ideally integrating the error catching with Juju's mechanisms.
             raise TooManyRelatedApps(relation_name, num_related, 1)
 
-    def relation_by_id(self, relation_name, relation_id):
+    def get_relation_by_id(self, relation_name, relation_id):
         def _norm(relation_id):
             # Relation IDs can be in the form '{relation_name}:{id}', so we need to
             # normalize them to just '{id}' for comparison.

--- a/test/bin/relation-ids
+++ b/test/bin/relation-ids
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 case $1 in
-    db) echo '["db:0"]' ;;
-    mon) echo '["mon:0"]' ;;
-    ha) echo '["ha:0"]' ;;
+    db) echo '["db:1"]' ;;
+    mon) echo '["mon:2"]' ;;
+    ha) echo '[]' ;;
     db0) echo '[]' ;;
-    db1) echo '["db1:1"]' ;;
-    db2) echo '["db2:1", "db2:2"]' ;;
+    db1) echo '["db1:4"]' ;;
+    db2) echo '["db2:5", "db2:6"]' ;;
     *) echo '[]' ;;
 esac

--- a/test/bin/relation-ids
+++ b/test/bin/relation-ids
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+case $1 in
+    db) echo '["db:0"]' ;;
+    mon) echo '["mon:0"]' ;;
+    ha) echo '["ha:0"]' ;;
+    db0) echo '[]' ;;
+    db1) echo '["db1:1"]' ;;
+    db2) echo '["db2:1", "db2:2"]' ;;
+    *) echo '[]' ;;
+esac

--- a/test/bin/relation-list
+++ b/test/bin/relation-list
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+case $2 in
+    db1:1) echo '["remoteapp1/0"]' ;;
+    db2:1) echo '["remoteapp1/0"]' ;;
+    db2:2) echo '["remoteapp2/0"]' ;;
+    *) echo '[]' ;;
+esac

--- a/test/bin/relation-list
+++ b/test/bin/relation-list
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 case $2 in
-    db1:1) echo '["remoteapp1/0"]' ;;
-    db2:1) echo '["remoteapp1/0"]' ;;
-    db2:2) echo '["remoteapp2/0"]' ;;
-    *) echo '[]' ;;
+    1) echo '["remote/0"]' ;;
+    2) echo '["remote/0"]' ;;
+    3) exit 2 ;;
+    4) echo '["remoteapp1/0"]' ;;
+    5) echo '["remoteapp1/0"]' ;;
+    6) echo '["remoteapp2/0"]' ;;
+    *) exit 2 ;;
 esac

--- a/test/charms/test_main/lib/charm.py
+++ b/test/charms/test_main/lib/charm.py
@@ -80,14 +80,17 @@ class Charm(CharmBase):
     def on_db_relation_joined(self, event):
         self._state['on_db_relation_joined'].append(type(event))
         self._state['observed_event_types'].append(type(event))
+        self._state['db_relation_joined_data'] = event.snapshot()
         self._write_state()
 
     def on_mon_relation_changed(self, event):
         self._state['on_mon_relation_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
+        self._state['mon_relation_changed_data'] = event.snapshot()
         self._write_state()
 
     def on_ha_relation_broken(self, event):
         self._state['on_ha_relation_broken'].append(type(event))
         self._state['observed_event_types'].append(type(event))
+        self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -78,7 +78,7 @@ class TestCharm(unittest.TestCase):
                         self.framework.observe(bound_event, self.on_any_relation)
 
             def on_any_relation(self, event):
-                assert event.relation.relation_name == 'req1'
+                assert event.relation.name == 'req1'
                 self.seen.append(f'{type(event).__name__}')
 
         self.meta = CharmMeta({

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from juju.charm import CharmBase, CharmMeta
 from juju.charm import CharmEvents
 from juju.framework import Framework, Event, EventBase
-from juju.model import DeadRelation, Model, ModelBackend
+from juju.model import Model, ModelBackend
 
 
 class TestCharm(unittest.TestCase):
@@ -99,7 +99,7 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
-        rel = DeadRelation('req1', '0')
+        rel = charm.framework.model.get_relation('req1', 0)
         unit = charm.framework.model.get_unit('app/0')
         charm.on.req1_relation_joined.emit(rel, unit)
         charm.on.req1_relation_changed.emit(rel, unit)

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 import unittest
 import tempfile
 import shutil
@@ -9,11 +10,14 @@ from pathlib import Path
 from juju.charm import CharmBase, CharmMeta
 from juju.charm import CharmEvents
 from juju.framework import Framework, Event, EventBase
+from juju.model import DeadRelation, Model, ModelBackend
 
 
 class TestCharm(unittest.TestCase):
 
     def setUp(self):
+        self._path = os.environ['PATH']
+        os.environ['PATH'] = str(Path(__file__).parent / 'bin')
         self.tmpdir = Path(tempfile.mkdtemp())
         self.meta = CharmMeta()
 
@@ -29,11 +33,13 @@ class TestCharm(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
+        os.environ['PATH'] = self._path
 
         CharmBase.on = CharmEvents()
 
     def create_framework(self):
-        framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, None)
+        model = Model('local/0', list(self.meta.relations), ModelBackend())
+        framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, model)
         self.addCleanup(framework.close)
         return framework
 
@@ -72,6 +78,7 @@ class TestCharm(unittest.TestCase):
                         self.framework.observe(bound_event, self.on_any_relation)
 
             def on_any_relation(self, event):
+                assert event.relation.relation_name == 'req1'
                 self.seen.append(f'{type(event).__name__}')
 
         self.meta = CharmMeta({
@@ -92,13 +99,15 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
-        charm.on.req1_relation_joined.emit()
-        charm.on.req1_relation_changed.emit()
-        charm.on.req_2_relation_changed.emit()
-        charm.on.pro1_relation_departed.emit()
-        charm.on.pro_2_relation_departed.emit()
-        charm.on.peer1_relation_broken.emit()
-        charm.on.peer_2_relation_broken.emit()
+        rel = DeadRelation('req1', '0')
+        unit = charm.framework.model.get_unit('app/0')
+        charm.on.req1_relation_joined.emit(rel, unit)
+        charm.on.req1_relation_changed.emit(rel, unit)
+        charm.on.req_2_relation_changed.emit(rel, unit)
+        charm.on.pro1_relation_departed.emit(rel, unit)
+        charm.on.pro_2_relation_departed.emit(rel, unit)
+        charm.on.peer1_relation_broken.emit(rel)
+        charm.on.peer_2_relation_broken.emit(rel)
 
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -102,15 +102,24 @@ class TestMain(unittest.TestCase):
 
     def _simulate_event(self, event_name, charm_config):
         event_hook = JUJU_CHARM_DIR / f"hooks/{event_name.replace('_', '-')}"
+        env = {
+            'PATH': str(Path(__file__).parent / 'bin'),
+            'JUJU_CHARM_DIR': JUJU_CHARM_DIR,
+            'JUJU_UNIT_NAME': 'test_main/0',
+            'CHARM_CONFIG': charm_config,
+        }
+        if 'relation' in event_name:
+            env.update({
+                'JUJU_RELATION': event_name.split('_')[0],
+                'JUJU_RELATION_ID': '0',
+            })
+            if 'broken' not in event_name:
+                env.update({
+                    'JUJU_REMOTE_UNIT': 'remote/0',
+                })
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
-        subprocess.check_call(
-            [sys.executable, event_hook],
-            env={
-                'JUJU_CHARM_DIR': JUJU_CHARM_DIR,
-                'JUJU_UNIT_NAME': 'test_main/0',
-                'CHARM_CONFIG': charm_config,
-            })
+        subprocess.check_call([sys.executable, event_hook], env=env)
         return self._read_and_clear_state()
 
     def test_event_reemitted(self):
@@ -143,6 +152,12 @@ class TestMain(unittest.TestCase):
             'ha_relation_broken': RelationBrokenEvent,
         }
 
+        expected_event_data = {
+            'db_relation_joined': {'relation_name': 'db', 'relation_id': 'db:0', 'unit_name': 'remote/0'},
+            'mon_relation_changed': {'relation_name': 'mon', 'relation_id': 'mon:0', 'unit_name': 'remote/0'},
+            'ha_relation_broken': {'relation_name': 'ha', 'relation_id': 'ha:0'},
+        }
+
         logger.debug(f'Expected events {events_under_test}')
 
         charm_config = base64.b64encode(pickle.dumps({
@@ -164,6 +179,9 @@ class TestMain(unittest.TestCase):
             self.assertEqual(handled_event_type, event)
 
             self.assertEqual(state['observed_event_types'], [event])
+
+            if event_kind in expected_event_data:
+                self.assertEqual(state[f'{event_kind}_data'], expected_event_data[event_kind])
 
     def test_event_not_implemented(self):
         """Make sure events without implementation do not cause non-zero exit.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -109,9 +109,11 @@ class TestMain(unittest.TestCase):
             'CHARM_CONFIG': charm_config,
         }
         if 'relation' in event_name:
+            rel_name = event_name.split('_')[0]
+            rel_id = {'db': '1', 'mon': '2', 'ha': '3'}[rel_name]
             env.update({
-                'JUJU_RELATION': event_name.split('_')[0],
-                'JUJU_RELATION_ID': '0',
+                'JUJU_RELATION': rel_name,
+                'JUJU_RELATION_ID': rel_id,
             })
             if 'broken' not in event_name:
                 env.update({
@@ -153,9 +155,9 @@ class TestMain(unittest.TestCase):
         }
 
         expected_event_data = {
-            'db_relation_joined': {'relation_name': 'db', 'relation_id': 'db:0', 'unit_name': 'remote/0'},
-            'mon_relation_changed': {'relation_name': 'mon', 'relation_id': 'mon:0', 'unit_name': 'remote/0'},
-            'ha_relation_broken': {'relation_name': 'ha', 'relation_id': 'ha:0'},
+            'db_relation_joined': {'relation_name': 'db', 'relation_id': 1, 'unit_name': 'remote/0'},
+            'mon_relation_changed': {'relation_name': 'mon', 'relation_id': 2, 'unit_name': 'remote/0'},
+            'ha_relation_broken': {'relation_name': 'ha', 'relation_id': 3},
         }
 
         logger.debug(f'Expected events {events_under_test}')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -16,35 +16,35 @@ class TestModelBackend:
     def relation_ids(self, relation_name):
         return {
             'db0': [],
-            'db1': ['db1:1'],
-            'db2': ['db2:1', 'db2:2'],
+            'db1': ['db1:4'],
+            'db2': ['db2:5', 'db2:6'],
         }[relation_name]
 
     def relation_list(self, relation_id):
         return {
-            'db1:1': ['remoteapp1/0'],
-            'db2:1': ['remoteapp1/0'],
-            'db2:2': ['remoteapp2/0'],
+            4: ['remoteapp1/0'],
+            5: ['remoteapp1/0'],
+            6: ['remoteapp2/0'],
         }[relation_id]
 
     def relation_get(self, relation_id, member_name):
         return {
-            'db1:1': {
+            4: {
                 'myapp/0': {'host': 'myapp-0'},
                 'remoteapp1/0': {'host': 'remoteapp1-0'},
             },
-            'db2:1': {
+            5: {
                 'myapp/0': {'host': 'myapp-0'},
                 'remoteapp1/0': {'host': 'remoteapp1-0'},
             },
-            'db2:2': {
+            6: {
                 'myapp/0': {'host': 'myapp-0'},
                 'remoteapp2/0': {'host': 'remoteapp2-0'},
             },
         }[relation_id][member_name]
 
     def relation_set(self, relation_id, key, value):
-        if relation_id == 'db2:1':
+        if relation_id == 5:
             raise ValueError()
         self.relation_set_calls.append((relation_id, key, value))
 
@@ -98,7 +98,7 @@ class TestModel(unittest.TestCase):
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[self.model.unit])
         rel_db1.data[self.model.unit]['host'] = 'bar'
-        self.assertEqual(self.backend.relation_set_calls, [('db1:1', 'host', 'bar')])
+        self.assertEqual(self.backend.relation_set_calls, [(4, 'host', 'bar')])
         self.assertEqual(rel_db1.data[self.model.unit]['host'], 'bar')
 
     def test_relation_data_del_key(self):
@@ -106,7 +106,7 @@ class TestModel(unittest.TestCase):
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[self.model.unit])
         del rel_db1.data[self.model.unit]['host']
-        self.assertEqual(self.backend.relation_set_calls, [('db1:1', 'host', '')])
+        self.assertEqual(self.backend.relation_set_calls, [(4, 'host', '')])
         self.assertNotIn('host', rel_db1.data[self.model.unit])
 
     def test_relation_set_fail(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -16,8 +16,8 @@ class TestModelBackend:
     def relation_ids(self, relation_name):
         return {
             'db0': [],
-            'db1': ['db1:4'],
-            'db2': ['db2:5', 'db2:6'],
+            'db1': [4],
+            'db2': [5, 6],
         }[relation_name]
 
     def relation_list(self, relation_id):
@@ -70,9 +70,14 @@ class TestModel(unittest.TestCase):
             unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
             self.assertIs(self.model.unit, unit_from_rel)
 
-    def test_relation_helper(self):
+    def test_get_relation(self):
+        with self.assertRaises(juju.model.ModelError):
+            self.model.get_relation('db1', 'db1:4')
+        db1_4 = self.model.get_relation('db1', 4)
+        self.assertIsInstance(db1_4, juju.model.Relation)
+        self.assertIsInstance(self.model.get_relation('db1', 7), juju.model.DeadRelation)
         self.assertIsNone(self.model.get_relation('db0'))
-        self.assertIsInstance(self.model.get_relation('db1'), juju.model.Relation)
+        self.assertIs(self.model.get_relation('db1'), db1_4)
         with self.assertRaises(juju.model.TooManyRelatedApps):
             self.model.get_relation('db2')
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -71,21 +71,21 @@ class TestModel(unittest.TestCase):
             self.assertIs(self.model.unit, unit_from_rel)
 
     def test_relation_helper(self):
-        self.assertIsNone(self.model.relation('db0'))
-        self.assertIsInstance(self.model.relation('db1'), juju.model.Relation)
+        self.assertIsNone(self.model.get_relation('db0'))
+        self.assertIsInstance(self.model.get_relation('db1'), juju.model.Relation)
         with self.assertRaises(juju.model.TooManyRelatedApps):
-            self.model.relation('db2')
+            self.model.get_relation('db2')
 
     def test_relation_data(self):
         random_unit = self.model._cache.get(juju.model.Unit, 'randomunit/0')
         with self.assertRaises(KeyError):
-            self.model.relation('db1').data[random_unit]
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.relation('db1').units))
-        self.assertEqual(self.model.relation('db1').data[remoteapp1_0], {'host': 'remoteapp1-0'})
+            self.model.get_relation('db1').data[random_unit]
+        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
+        self.assertEqual(self.model.get_relation('db1').data[remoteapp1_0], {'host': 'remoteapp1-0'})
 
     def test_relation_data_modify_remote(self):
-        rel_db1 = self.model.relation('db1')
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.relation('db1').units))
+        rel_db1 = self.model.get_relation('db1')
+        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[remoteapp1_0])
         with self.assertRaises(juju.model.RelationDataError):
@@ -94,7 +94,7 @@ class TestModel(unittest.TestCase):
         self.assertNotIn('foo', rel_db1.data[remoteapp1_0])
 
     def test_relation_data_modify_local(self):
-        rel_db1 = self.model.relation('db1')
+        rel_db1 = self.model.get_relation('db1')
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[self.model.unit])
         rel_db1.data[self.model.unit]['host'] = 'bar'
@@ -102,7 +102,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(rel_db1.data[self.model.unit]['host'], 'bar')
 
     def test_relation_data_del_key(self):
-        rel_db1 = self.model.relation('db1')
+        rel_db1 = self.model.get_relation('db1')
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[self.model.unit])
         del rel_db1.data[self.model.unit]['host']
@@ -121,7 +121,7 @@ class TestModel(unittest.TestCase):
         self.assertIn('host', rel_db2.data[self.model.unit])
 
     def test_relation_data_type_check(self):
-        rel_db1 = self.model.relation('db1')
+        rel_db1 = self.model.get_relation('db1')
         with self.assertRaises(juju.model.RelationDataError):
             rel_db1.data[self.model.unit]['foo'] = 1
         with self.assertRaises(juju.model.RelationDataError):


### PR DESCRIPTION
Add the args required for relation events to be meaningful. Must also handle the case where the unit or even relation is no longer available.