### PR TITLE
Remove DeadRelation in favor of empty relations

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -63,6 +63,7 @@ class RelationUnitEvent(RelationEvent):
     def restore(self, snapshot):
         super().restore(snapshot)
         self.unit = self.framework.model.get_unit(snapshot['unit_name'])
+        self.relation.data._data = {self.unit: {}, self.framework.model.unit: {}}
 
 class RelationJoinedEvent(RelationUnitEvent):
     pass

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -63,7 +63,6 @@ class RelationUnitEvent(RelationEvent):
     def restore(self, snapshot):
         super().restore(snapshot)
         self.unit = self.framework.model.get_unit(snapshot['unit_name'])
-        self.relation.data._data = {self.unit: {}, self.framework.model.unit: {}}
 
 class RelationJoinedEvent(RelationUnitEvent):
     pass

--- a/juju/model.py
+++ b/juju/model.py
@@ -139,7 +139,7 @@ class Relation:
                 self.units.add(unit)
                 self.apps.add(unit.app)
         except RelationNotFound:
-            # If the relation is dead, just treat it as if it has no units.
+            # If the relation is dead, just treat it as if it has no remote units.
             pass
         self.data = RelationData(self, local_unit, backend)
 
@@ -179,6 +179,7 @@ class RelationUnitData(LazyMapping, MutableMapping):
         try:
             return self._backend.relation_get(self.relation.id, self.unit.name)
         except RelationNotFound:
+            # Dead relations tell no tales (and have no data).
             return {}
 
     def __setitem__(self, key, value):

--- a/juju/model.py
+++ b/juju/model.py
@@ -249,6 +249,9 @@ class ModelBackend:
         try:
             return self._run('relation-list', '-r', str(relation_id))
         except CalledProcessError as e:
+            # TODO: This should use the return code if it is specific enough rather than the message.
+            # It seems to be 2 for this error, but I haven't been able to confirm yet if that might
+            # also apply to other error cases.
             if b'relation not found' in e.stderr:
                 raise RelationNotFound() from e
             else:
@@ -258,6 +261,9 @@ class ModelBackend:
         try:
             return self._run('relation-get', '-r', str(relation_id), '-', member_name)
         except CalledProcessError as e:
+            # TODO: This should use the return code if it is specific enough rather than the message.
+            # It seems to be 2 for this error, but I haven't been able to confirm yet if that might
+            # also apply to other error cases.
             if b'relation not found' in e.stderr:
                 raise RelationNotFound() from e
             else:

--- a/test/bin/relation-list
+++ b/test/bin/relation-list
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+fail_not_found() {
+    1>&2 echo "ERROR invalid value \"$1\" for option -r: relation not found"
+    exit 2
+}
+
 case $2 in
     1) echo '["remote/0"]' ;;
     2) echo '["remote/0"]' ;;
-    3) exit 2 ;;
+    3) fail_not_found $2 ;;
     4) echo '["remoteapp1/0"]' ;;
     5) echo '["remoteapp1/0"]' ;;
     6) echo '["remoteapp2/0"]' ;;
-    *) exit 2 ;;
+    *) fail_not_found $2 ;;
 esac


### PR DESCRIPTION
Instead of treating dead relations as a separate type, handle missing relation errors more consistently and just treat them as not having any remove members or data.