### PR TITLE
Support scoped event lookup

### DIFF
--- a/juju/framework.py
+++ b/juju/framework.py
@@ -259,12 +259,12 @@ class EventsBase(Object):
 
 
 class PrefixedEvents:
-    def __init__(self, emitter, key):
+    def __init__(self, emitter, prefix):
         self._emitter = emitter
-        self._prefix = key.replace("-", "_") + '_'
+        self._prefix = prefix
 
     def __getattr__(self, name):
-        return getattr(self._emitter, self._prefix + name)
+        return getattr(self._emitter, self._prefix + '_' + name)
 
 
 class PreCommitEvent(EventBase):

--- a/juju/framework.py
+++ b/juju/framework.py
@@ -260,12 +260,11 @@ class EventsBase(Object):
 
 class PrefixedEvents:
     def __init__(self, emitter, key):
-        prefix = key.replace("-", "_") + '_'
-        for event_name, bound_event in emitter.events().items():
-            if not event_name.startswith(prefix):
-                continue
-            unprefixed_event_name = event_name[len(prefix):]
-            setattr(self, unprefixed_event_name, bound_event)
+        self._emitter = emitter
+        self._prefix = key.replace("-", "_") + '_'
+
+    def __getattr__(self, name):
+        return getattr(self._emitter, self._prefix + name)
 
 
 class PreCommitEvent(EventBase):

--- a/juju/framework.py
+++ b/juju/framework.py
@@ -259,12 +259,12 @@ class EventsBase(Object):
 
 
 class PrefixedEvents:
-    def __init__(self, emitter, prefix):
+    def __init__(self, emitter, key):
         self._emitter = emitter
-        self._prefix = prefix
+        self._prefix = key.replace("-", "_") + '_'
 
     def __getattr__(self, name):
-        return getattr(self._emitter, self._prefix + '_' + name)
+        return getattr(self._emitter, self._prefix + name)
 
 
 class PreCommitEvent(EventBase):

--- a/juju/framework.py
+++ b/juju/framework.py
@@ -6,6 +6,9 @@ import sqlite3
 import collections
 import keyword
 
+from collections import namedtuple
+
+
 class Handle:
     """Handle defines a name for an object in the form of a hierarchical path.
 
@@ -252,6 +255,16 @@ class EventsBase(Object):
                 bound_event = getattr(self, event_kind)
                 events_map[event_kind] = bound_event
         return events_map
+
+    def __getitem__(self, key):
+        prefix = f'{key.replace("-", "_")}_'
+        scoped_events = {}
+        for event_name, bound_event in self.events().items():
+            if event_name.startswith(prefix):
+                unprefixed_event_name = event_name[len(prefix):]
+                scoped_events[unprefixed_event_name] = bound_event
+        events_scope = namedtuple('EventsScope', scoped_events.keys())
+        return events_scope(**scoped_events)
 
 
 class PreCommitEvent(EventBase):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -72,10 +72,12 @@ class TestCharm(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args)
                 self.seen = []
-                for event_kind, bound_event in self.on.events().items():
-                    # hook up relation events to generic handler
-                    if 'relation' in event_kind:
-                        self.framework.observe(bound_event, self.on_any_relation)
+                for rel in ('req1', 'req-2', 'pro1', 'pro-2', 'peer1', 'peer-2'):
+                    # Hook up relation events to generic handler.
+                    self.framework.observe(self.on[rel].relation_joined, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_changed, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_departed, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_broken, self.on_any_relation)
 
             def on_any_relation(self, event):
                 assert event.relation.name == 'req1'
@@ -99,15 +101,19 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
+        actual_scoped_events = set(charm.on['req1']._fields)
+        expected_scoped_events = {'relation_joined', 'relation_changed', 'relation_departed', 'relation_broken'}
+        self.assertEqual(actual_scoped_events, expected_scoped_events)
+
         rel = charm.framework.model.get_relation('req1', 0)
         unit = charm.framework.model.get_unit('app/0')
-        charm.on.req1_relation_joined.emit(rel, unit)
-        charm.on.req1_relation_changed.emit(rel, unit)
-        charm.on.req_2_relation_changed.emit(rel, unit)
-        charm.on.pro1_relation_departed.emit(rel, unit)
-        charm.on.pro_2_relation_departed.emit(rel, unit)
-        charm.on.peer1_relation_broken.emit(rel)
-        charm.on.peer_2_relation_broken.emit(rel)
+        charm.on['req1'].relation_joined.emit(rel, unit)
+        charm.on['req1'].relation_changed.emit(rel, unit)
+        charm.on['req-2'].relation_changed.emit(rel, unit)
+        charm.on['pro1'].relation_departed.emit(rel, unit)
+        charm.on['pro-2'].relation_departed.emit(rel, unit)
+        charm.on['peer1'].relation_broken.emit(rel)
+        charm.on['peer-2'].relation_broken.emit(rel)
 
         self.assertEqual(charm.seen, [
             'RelationJoinedEvent',
@@ -125,10 +131,10 @@ class TestCharm(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args)
                 self.seen = []
-                self.framework.observe(self.on.stor1_storage_attached, self)
-                self.framework.observe(self.on.stor2_storage_detaching, self)
-                self.framework.observe(self.on.stor3_storage_attached, self)
-                self.framework.observe(self.on.stor_4_storage_attached, self)
+                self.framework.observe(self.on['stor1'].storage_attached, self)
+                self.framework.observe(self.on['stor2'].storage_detaching, self)
+                self.framework.observe(self.on['stor3'].storage_attached, self)
+                self.framework.observe(self.on['stor-4'].storage_attached, self)
 
             def on_stor1_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
@@ -174,10 +180,10 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
-        charm.on.stor1_storage_attached.emit()
-        charm.on.stor2_storage_detaching.emit()
-        charm.on.stor3_storage_attached.emit()
-        charm.on.stor_4_storage_attached.emit()
+        charm.on['stor1'].storage_attached.emit()
+        charm.on['stor2'].storage_detaching.emit()
+        charm.on['stor3'].storage_attached.emit()
+        charm.on['stor-4'].storage_attached.emit()
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -101,10 +101,6 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
-        actual_scoped_events = set(charm.on['req1']._fields)
-        expected_scoped_events = {'relation_joined', 'relation_changed', 'relation_departed', 'relation_broken'}
-        self.assertEqual(actual_scoped_events, expected_scoped_events)
-
         rel = charm.framework.model.get_relation('req1', 0)
         unit = charm.framework.model.get_unit('app/0')
         charm.on['req1'].relation_joined.emit(rel, unit)


### PR DESCRIPTION
Allow for lookup of events scoped by a prefix, per continued discussion on how to handle relation and storage events which have a dynamic prefix.