### PR TITLE
Prevent many instances of BoundEvents being created

### DIFF
--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -99,6 +99,9 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
+        # Confirm that we always get the same BoundEvent instance for a given event.
+        self.assertIs(charm.on.start, charm.on.start)
+
         rel = charm.framework.model.get_relation('req1', 0)
         unit = charm.framework.model.get_unit('app/0')
         charm.on.req1_relation_joined.emit(rel, unit)


### PR DESCRIPTION
Prevent a new instance of BoundEvent being created every time an event attribute is accessed by permanently binding the BoundEvent instance to the EventsBase instance and permanently binding the EventsBase instance to the parent.