### PR TITLE
Change Relation.apps to Relation.app

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -131,13 +131,14 @@ class Relation:
     def __init__(self, relation_name, relation_id, local_unit, backend, cache):
         self.name = relation_name
         self.id = relation_id
-        self.apps = set()
+        self.app = None
         self.units = set()
         try:
             for unit_name in backend.relation_list(self.id):
                 unit = cache.get(Unit, unit_name)
                 self.units.add(unit)
-                self.apps.add(unit.app)
+                if self.app is None:
+                    self.app = unit.app
         except RelationNotFound:
             # If the relation is dead, just treat it as if it has no remote units.
             pass

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -81,7 +81,8 @@ class TestCharm(unittest.TestCase):
 
             def on_any_relation(self, event):
                 assert event.relation.name == 'req1'
-                self.seen.append(f'{type(event).__name__}')
+                assert event.relation.app.name == 'remote'
+                self.seen.append(type(event).__name__)
 
         self.meta = CharmMeta({
             'name': 'my-charm',
@@ -101,8 +102,8 @@ class TestCharm(unittest.TestCase):
 
         charm = MyCharm(self.create_framework(), None)
 
-        rel = charm.framework.model.get_relation('req1', 0)
-        unit = charm.framework.model.get_unit('app/0')
+        rel = charm.framework.model.get_relation('req1', 1)
+        unit = charm.framework.model.get_unit('remote/0')
         charm.on['req1'].relation_joined.emit(rel, unit)
         charm.on['req1'].relation_changed.emit(rel, unit)
         charm.on['req-2'].relation_changed.emit(rel, unit)


### PR DESCRIPTION
Each relation ID (and thus Relation instance) is associated with a single remote application. Therefore, it doesn't make sense to have a set of Applications on the Relation, since it will always contain a single item.